### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/rg-engineering/ioBroker.amtronwallbox"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "3.0.3",
     "axios": "1.4.0",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 due to npm6 not installing peer dependencies.
So this adapter must require node 16 or newer